### PR TITLE
Burn singleton 🔥

### DIFF
--- a/bin/produce
+++ b/bin/produce
@@ -31,7 +31,6 @@ class FastlaneApplication
       c.action do |args, options|
         set_username(options.username)
 
-        Produce::Config.shared_config # to ask for missing information right in the beginning
         puts Produce::Manager.start_producing
       end
     end

--- a/lib/produce/config.rb
+++ b/lib/produce/config.rb
@@ -8,14 +8,8 @@ module Produce
       primary_language: "Primary Language (e.g. 'English', 'German'): "
     }
 
-    attr_reader :config
-
     # Leaved to keep Fastline from crashing. Should be removed upon version bump.
     def self.shared_config
-    end
-
-    def self.shared_config= config
-      @@shared = config
     end
 
     def self.env_options

--- a/lib/produce/config.rb
+++ b/lib/produce/config.rb
@@ -42,7 +42,7 @@ module Produce
       return @config[key]
     end
 
-    # Aliases `[key]` to `val(key)` because Ruby allows that.
+    # Aliases `[key]` to `val(key)` because Ruby can do it.
     alias_method :[], :val
 
     # Returns true if option for the given key is present.

--- a/lib/produce/config.rb
+++ b/lib/produce/config.rb
@@ -8,7 +8,7 @@ module Produce
       primary_language: "Primary Language (e.g. 'English', 'German'): "
     }
 
-    # Leaved to keep Fastline from crashing. Should be removed upon version bump.
+    # Left to prevent fastlane from crashing. Should be removed upon version bump.
     def self.shared_config
     end
 

--- a/lib/produce/config.rb
+++ b/lib/produce/config.rb
@@ -12,10 +12,17 @@ module Produce
     def self.shared_config
     end
 
+    # Creates new Config instance using ENV variables.
+    # @param options (Hash) (optional) config options hash. If duplicates keys
+    # specified by ENV variable, `options` has value will be used.
+    # @return (Config) created Config instance
     def initialize(options = {})
       @config = env_options.merge(options)
     end
 
+    # Retrieves the value for given `key`. If not found, will promt user with
+    # `ASK_MESSAGES[key]` till gets valid response. Thus, always returns value.
+    # Raises exception if given `key` is not Symbol or unknown.
     def val(key)
       raise "Please only pass symbols, no Strings to this method".red unless key.kind_of? Symbol
 
@@ -35,6 +42,7 @@ module Produce
       return @config[key]
     end
 
+    # Aliases `[key]` to `val(key)` because Ruby allows that.
     alias_method :[], :val
 
     private

--- a/lib/produce/config.rb
+++ b/lib/produce/config.rb
@@ -10,8 +10,8 @@ module Produce
 
     attr_reader :config
 
+    # Leaved to keep Fastline from crashing. Should be removed upon version bump.
     def self.shared_config
-      @@shared ||= self.new
     end
 
     def self.shared_config= config

--- a/lib/produce/config.rb
+++ b/lib/produce/config.rb
@@ -45,6 +45,11 @@ module Produce
     # Aliases `[key]` to `val(key)` because Ruby allows that.
     alias_method :[], :val
 
+    # Returns true if option for the given key is present.
+    def has_key?(key)
+      @config.has_key? key
+    end
+
     private
 
     def env_options
@@ -71,10 +76,6 @@ module Produce
       hash
     end
 
-
-    def has_key?(key)
-      @config.has_key? key
-    end
 
     def is_valid_language? language
       AvailableDefaultLanguages.all_langauges.include? language

--- a/lib/produce/developer_center.rb
+++ b/lib/produce/developer_center.rb
@@ -29,7 +29,9 @@ module Produce
 
 
 
-    def initialize
+    def initialize(config)
+      @config = config
+
       FileUtils.mkdir_p TMP_FOLDER
       
       Capybara.run_server = false
@@ -195,14 +197,14 @@ module Produce
 
     def create_new_app
       if app_exists?
-        Helper.log.info "App '#{Config.val(:app_name)}' already exists, nothing to do on the Dev Center".green
+        Helper.log.info "App '#{@config[:app_name]}' already exists, nothing to do on the Dev Center".green
         ENV["CREATED_NEW_APP_ID"] = nil
         # Nothing to do here
       else
-        Helper.log.info "Creating new app '#{Config.val(:app_name)}' on the Apple Dev Center".green
+        Helper.log.info "Creating new app '#{@config[:app_name]}' on the Apple Dev Center".green
         visit CREATE_APP_URL
-        wait_for_elements("*[name='appIdName']").first.set Config.val(:app_name)
-        wait_for_elements("*[name='explicitIdentifier']").first.set Config.val(:bundle_identifier)
+        wait_for_elements("*[name='appIdName']").first.set @config[:app_name]
+        wait_for_elements("*[name='explicitIdentifier']").first.set @config[:bundle_identifier]
         click_next
 
         sleep 3 # sometimes this takes a while and we don't want to timeout
@@ -219,7 +221,7 @@ module Produce
 
         ENV["CREATED_NEW_APP_ID"] = Time.now.to_s
 
-        Helper.log.info "Finished creating new app '#{Config.val(:app_name)}' on the Dev Center".green
+        Helper.log.info "Finished creating new app '#{@config[:app_name]}' on the Dev Center".green
       end
 
       return true
@@ -233,7 +235,7 @@ module Produce
         wait_for_elements("td[aria-describedby='grid-table_identifier']").each do |app|
           identifier = app['title']
 
-          return true if identifier.to_s == Config.val(:bundle_identifier).to_s
+          return true if identifier.to_s == @config[:bundle_identifier].to_s
         end
 
         false

--- a/lib/produce/itunes_connect.rb
+++ b/lib/produce/itunes_connect.rb
@@ -21,8 +21,9 @@ module Produce
 
     NEW_APP_CLASS = ".new-button.ng-isolate-scope"
     
-    def initialize
+    def initialize(config)
       super
+      @config = config
 
       DependencyChecker.check_dependencies
       
@@ -119,10 +120,10 @@ module Produce
 
     def create_new_app
       if app_exists?
-        Helper.log.info "App '#{Config.val(:app_name)}' exists already, nothing to do on iTunes Connect".green
+        Helper.log.info "App '#{config[:app_name]}' exists already, nothing to do on iTunes Connect".green
         # Nothing to do here
       else
-        Helper.log.info "Creating new app '#{Config.val(:app_name)}' on iTunes Connect".green
+        Helper.log.info "Creating new app '#{config[:app_name]}' on iTunes Connect".green
 
         initial_create
 
@@ -130,7 +131,7 @@ module Produce
 
         raise "Something went wrong when creating the new app - it's not listed in the App's list" unless app_exists?
 
-        Helper.log.info "Finished creating new app '#{Config.val(:app_name)}' on iTunes Connect".green
+        Helper.log.info "Finished creating new app '#{config[:app_name]}' on iTunes Connect".green
       end
 
       return fetch_apple_id
@@ -138,12 +139,12 @@ module Produce
 
     def fetch_apple_id
       # First try it using the Apple API
-      data = JSON.parse(open("https://itunes.apple.com/lookup?bundleId=#{Config.val(:bundle_identifier)}").read)
+      data = JSON.parse(open("https://itunes.apple.com/lookup?bundleId=#{config[:bundle_identifier]}").read)
 
       if data['resultCount'] == 0 or true
         visit current_url
         sleep 10
-        first("input[ng-model='searchModel']").set Config.val(:bundle_identifier)
+        first("input[ng-model='searchModel']").set config[:bundle_identifier]
 
         if all("div[bo-bind='app.name']").count == 2
           raise "There were multiple results when looking for the new app. This might be due to having same app identifiers included in each other (see generated screenshots)".red
@@ -163,12 +164,12 @@ module Produce
       open_new_app_popup
       
       # Fill out the initial information
-      wait_for_elements("input[ng-model='createAppDetails.newApp.name.value']").first.set Config.val(:app_name)
-      wait_for_elements("input[ng-model='createAppDetails.versionString.value']").first.set Config.val(:version)
-      wait_for_elements("input[ng-model='createAppDetails.newApp.vendorId.value']").first.set Config.val(:sku)
+      wait_for_elements("input[ng-model='createAppDetails.newApp.name.value']").first.set config[:app_name]
+      wait_for_elements("input[ng-model='createAppDetails.versionString.value']").first.set config[:version]
+      wait_for_elements("input[ng-model='createAppDetails.newApp.vendorId.value']").first.set config[:sku]
       
-      wait_for_elements("option[value='#{Config.val(:bundle_identifier)}']").first.select_option
-      all(:xpath, "//option[text()='#{Config.val(:primary_language)}']").first.select_option
+      wait_for_elements("option[value='#{config[:bundle_identifier]}']").first.select_option
+      all(:xpath, "//option[text()='#{config[:primary_language]}']").first.select_option
 
       click_on "Create"
       sleep 5 # this usually takes some time
@@ -179,7 +180,7 @@ module Produce
 
       wait_for_elements(".language.hasPopOver") # looking good
 
-      Helper.log.info "Successfully created new app '#{Config.val(:app_name)}' on iTC. Setting up the initial information now.".green
+      Helper.log.info "Successfully created new app '#{config[:app_name]}' on iTC. Setting up the initial information now.".green
     end
 
     def initial_pricing
@@ -195,7 +196,7 @@ module Produce
 
         sleep 4
 
-        return (all("option[value='#{Config.val(:bundle_identifier)}']").count == 0)
+        return (all("option[value='#{config[:bundle_identifier]}']").count == 0)
       end
 
       def open_new_app_popup

--- a/lib/produce/itunes_connect.rb
+++ b/lib/produce/itunes_connect.rb
@@ -119,10 +119,10 @@ module Produce
 
     def create_new_app
       if app_exists?
-        Helper.log.info "App '#{config[:app_name]}' exists already, nothing to do on iTunes Connect".green
+        Helper.log.info "App '#{@config[:app_name]}' exists already, nothing to do on iTunes Connect".green
         # Nothing to do here
       else
-        Helper.log.info "Creating new app '#{config[:app_name]}' on iTunes Connect".green
+        Helper.log.info "Creating new app '#{@config[:app_name]}' on iTunes Connect".green
 
         initial_create
 
@@ -130,7 +130,7 @@ module Produce
 
         raise "Something went wrong when creating the new app - it's not listed in the App's list" unless app_exists?
 
-        Helper.log.info "Finished creating new app '#{config[:app_name]}' on iTunes Connect".green
+        Helper.log.info "Finished creating new app '#{@config[:app_name]}' on iTunes Connect".green
       end
 
       return fetch_apple_id
@@ -138,12 +138,12 @@ module Produce
 
     def fetch_apple_id
       # First try it using the Apple API
-      data = JSON.parse(open("https://itunes.apple.com/lookup?bundleId=#{config[:bundle_identifier]}").read)
+      data = JSON.parse(open("https://itunes.apple.com/lookup?bundleId=#{@config[:bundle_identifier]}").read)
 
       if data['resultCount'] == 0 or true
         visit current_url
         sleep 10
-        first("input[ng-model='searchModel']").set config[:bundle_identifier]
+        first("input[ng-model='searchModel']").set @config[:bundle_identifier]
 
         if all("div[bo-bind='app.name']").count == 2
           raise "There were multiple results when looking for the new app. This might be due to having same app identifiers included in each other (see generated screenshots)".red
@@ -163,12 +163,12 @@ module Produce
       open_new_app_popup
       
       # Fill out the initial information
-      wait_for_elements("input[ng-model='createAppDetails.newApp.name.value']").first.set config[:app_name]
-      wait_for_elements("input[ng-model='createAppDetails.versionString.value']").first.set config[:version]
-      wait_for_elements("input[ng-model='createAppDetails.newApp.vendorId.value']").first.set config[:sku]
+      wait_for_elements("input[ng-model='createAppDetails.newApp.name.value']").first.set @config[:app_name]
+      wait_for_elements("input[ng-model='createAppDetails.versionString.value']").first.set @config[:version]
+      wait_for_elements("input[ng-model='createAppDetails.newApp.vendorId.value']").first.set @config[:sku]
       
-      wait_for_elements("option[value='#{config[:bundle_identifier]}']").first.select_option
-      all(:xpath, "//option[text()='#{config[:primary_language]}']").first.select_option
+      wait_for_elements("option[value='#{@config[:bundle_identifier]}']").first.select_option
+      all(:xpath, "//option[text()='#{@config[:primary_language]}']").first.select_option
 
       click_on "Create"
       sleep 5 # this usually takes some time
@@ -179,7 +179,7 @@ module Produce
 
       wait_for_elements(".language.hasPopOver") # looking good
 
-      Helper.log.info "Successfully created new app '#{config[:app_name]}' on iTC. Setting up the initial information now.".green
+      Helper.log.info "Successfully created new app '#{@config[:app_name]}' on iTC. Setting up the initial information now.".green
     end
 
     def initial_pricing
@@ -195,7 +195,7 @@ module Produce
 
         sleep 4
 
-        return (all("option[value='#{config[:bundle_identifier]}']").count == 0)
+        return (all("option[value='#{@config[:bundle_identifier]}']").count == 0)
       end
 
       def open_new_app_popup

--- a/lib/produce/itunes_connect.rb
+++ b/lib/produce/itunes_connect.rb
@@ -22,7 +22,6 @@ module Produce
     NEW_APP_CLASS = ".new-button.ng-isolate-scope"
     
     def initialize(config)
-      super
       @config = config
 
       DependencyChecker.check_dependencies

--- a/lib/produce/manager.rb
+++ b/lib/produce/manager.rb
@@ -1,8 +1,11 @@
 module Produce
   class Manager
-    def self.start_producing
-      DeveloperCenter.new.run
-      return ItunesConnect.new.run unless Config.val(:skip_itc)
+    # Produces app at DeveloperCenter and ItunesConnect
+    # @param config (Config) (optional) config to use. Will fallback to
+    # config with ENV values if not specified.
+    def self.start_producing(config = Config.new)
+      DeveloperCenter.new(config).run
+      return ItunesConnect.new(config).run unless config[:skip_itc]
     end
   end
 end


### PR DESCRIPTION
Sorry, couldn't wait for your response. I kept all the API the same.

Notes:
- [`shared_config`](https://github.com/almassapargali/produce/compare/burn-singleton?expand=1#diff-5525317d2652bea041de1b415798ff5aL13) still there just to don't break API. You may want to remove it upon version bump (and on [fastline](https://github.com/KrauseFx/fastlane/blob/master/lib/fastlane/actions/produce.rb#L24), since it's used there).
- While `share_config` does nothing, the result is same because `Config.new` uses ENV values by default.
- There is still no need to pass `config` to `Manager.start_producing`, it'll use `Config.new` if none given.

Please note that this PR has conflicts with #7.
