### PR TITLE
Fix example of producer action in fastfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ lane :appstore do
     app_identifier: 'com.krausefx.app',
     app_name: 'MyApp',
     language: 'English',
-    version: '1.0',
+    app_version: '1.0',
     sku: 123,
     team_name: 'SunApps GmbH' # only necessary when in multiple teams
   )


### PR DESCRIPTION
According to https://github.com/fastlane/produce/blob/master/lib/produce/options.rb#L29, `version` is invalid option, and it's needed to use `app_version` instead.
