### PR TITLE
Make sku value a string in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ lane :appstore do
     app_name: 'MyApp',
     language: 'English',
     app_version: '1.0',
-    sku: 123,
+    sku: '123',
     team_name: 'SunApps GmbH' # only necessary when in multiple teams
   )
 


### PR DESCRIPTION
Make 'sku' value a string in README example, to avoid the following runtime error:

```
'sku' value must be a String! Found Fixnum instead.
```
