### PR TITLE
call select_team for ITC logins

### DIFF
--- a/lib/produce/itunes_connect.rb
+++ b/lib/produce/itunes_connect.rb
@@ -7,7 +7,8 @@ module Produce
       @full_bundle_identifier.gsub!('*', Produce.config[:bundle_identifier_suffix].to_s) if wildcard_bundle?
 
       Spaceship::Tunes.login(Produce.config[:username], nil)
-
+      Spaceship::Tunes.client.select_team
+      
       create_new_app
     end
 


### PR DESCRIPTION
added Spaceship::Tunes.client.select_team after login to support multi teams with produce.
